### PR TITLE
fix #50 correctly displays submenu at the bottom of the viewport

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -89,7 +89,7 @@ function getPosition(rect: Rect, pos: Point): Point {
             : pos.x < minX ? minX : pos.x,
         y: vdir === "d"
             ? pos.y + rect.height > maxY ? maxY - rect.height : pos.y
-            : pos.y < minY ? minY : pos.y
+            : pos.y < minY ? minY : pos.y + rect.height > maxY ? maxY - rect.height : pos.y
     };
 }
 


### PR DESCRIPTION
Takes the height of the submenu in account even if the vdir is "u"