### PR TITLE
Add Csp nonce support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,12 @@ Set a CSP (Content Security Policy) nonce to be used for the style element. This
 
 The nonce will be applied to the style element that contains the default menu styles.
 
+> [!IMPORTANT]
+> `setNonce` must be called **before the first menu is shown**. Once styles have been added to the DOM, calling `setNonce` will have no effect. In most cases this shouldn't matter, but make sure to call this method early in your application initialization.
+
 Example:
 ```typescript
-// Set a nonce for all menus
+// Set a nonce for all menus (must be called before showing any menu)
 ctxmenu.setNonce('your-csp-nonce-here');
 
 // Attach menus as usual

--- a/README.md
+++ b/README.md
@@ -177,13 +177,14 @@ This is a divider item which draws a horizontal line.
 
 This library exports a singleton object `ctxmenu`.
 In the standalone version the singleton is a global variable (`window.ctxmenu`).
-It has the following five APIs:
+It has the following six APIs:
 
 [attach](#ctxmenuattach)\
 [update](#ctxmenuupdate)\
 [delete](#ctxmenudelete)\
 [show](#ctxmenushow)\
-[hide](#ctxmenuhide)
+[hide](#ctxmenuhide)\
+[setNonce](#ctxmenusetnonce)
 
 ### Interfaces
 [CTXConfig](#ctxconfig)
@@ -244,6 +245,23 @@ ctxmenu.hide()
 ```
 Hide any open context menu. 
 
+### `ctxmenu.setNonce`
+```typescript
+ctxmenu.setNonce(nonce: string)
+```
+Set a CSP (Content Security Policy) nonce to be used for the style element. This is useful when you have a strict CSP that requires nonces for inline styles.
+
+The nonce will be applied to the style element that contains the default menu styles.
+
+Example:
+```typescript
+// Set a nonce for all menus
+ctxmenu.setNonce('your-csp-nonce-here');
+
+// Attach menus as usual
+ctxmenu.attach('#myElement', menuDefinition);
+```
+
 ## CTXConfig
 
 With this interface you can define __lifecycle events__ and __attributes__ for a context menu via the [attach](#ctxmenuattach) and [update](#ctxmenuupdate) methods.
@@ -253,7 +271,7 @@ With this interface you can define __lifecycle events__ and __attributes__ for a
     onShow?: (dom: HTMLUListElement) => void;
     onBeforeHide?: (dom: Element) => void;
     onHide?: (dom: Element) => void;
-    attributes?: Record<string, string>
+    attributes?: Record<string, string>;
 ```
 
 The `onBeforeShow` method can be used to change the menu definition just before it is shown. This can be useful to customize the menu based on the event properties (for example, the cursor position). The function must return a valid menu definition.
@@ -265,7 +283,6 @@ The `onBeforeHide` method can be used to execute code just before the menu is de
 The `onHide` method can be used to execute code after the menu is hidden. This can be useful to execute code that depends on the menu being hidden (for example, to reset the state of the menu). Will be called for any submenu that is closed as well. Gets passed a reference to the DOM element which has been removed.
 
 The `attributes` record can be used to define arbitrary attributes for the menu container (the UL element), like you can with the `Element.setAttribute` browser API, for example, `id`, `class` or data attributes.
-
 
 ## Custom Events
 

--- a/src/ctxmenu.ts
+++ b/src/ctxmenu.ts
@@ -28,6 +28,7 @@ class ContextMenu implements CTXMenuSingleton {
      * in that case we don't want to close the menu. (#28)
      */
     private preventCloseOnScroll = false;
+    private nonce: string | undefined;
     private constructor() {
         window.addEventListener("click", () => void this.hide());
         window.addEventListener("resize", () => void this.hide());
@@ -60,7 +61,8 @@ class ContextMenu implements CTXMenuSingleton {
             "delete": instance.delete.bind(instance),
             "hide": instance.hide.bind(instance),
             "show": instance.show.bind(instance),
-            "update": instance.update.bind(instance)
+            "update": instance.update.bind(instance),
+            "setNonce": instance.setNonce.bind(instance)
         };
     }
 
@@ -134,6 +136,10 @@ class ContextMenu implements CTXMenuSingleton {
         this._hide(this.menu);
     }
 
+    public setNonce(nonce: string): void {
+        this.nonce = nonce;
+    }
+
     private _hide(menuOrSubMenu: Element | undefined) {
         this.onBeforeHide?.(menuOrSubMenu);
         resetDirections();
@@ -183,6 +189,10 @@ class ContextMenu implements CTXMenuSingleton {
         }
         //insert default styles as first css -> low priority -> user can overwrite it easily
         const style = document.createElement("style");
+        const nonce = ContextMenu.instance?.nonce;
+        if (nonce) {
+            style.nonce = nonce;
+        }
         style.innerHTML = styles;
         document.head.insertBefore(style, document.head.childNodes[0]);
     }

--- a/src/ctxmenu.ts
+++ b/src/ctxmenu.ts
@@ -29,6 +29,7 @@ class ContextMenu implements CTXMenuSingleton {
      */
     private preventCloseOnScroll = false;
     private nonce: string | undefined;
+    private static stylesAdded = false;
     private constructor() {
         window.addEventListener("click", () => void this.hide());
         window.addEventListener("resize", () => void this.hide());
@@ -47,7 +48,6 @@ class ContextMenu implements CTXMenuSingleton {
         window.addEventListener("keydown", e => {
             if (e.key === "Escape") this.hide();
         });
-        ContextMenu.addStylesToDom();
     }
 
     public static getInstance(): CTXMenuSingleton {
@@ -112,6 +112,9 @@ class ContextMenu implements CTXMenuSingleton {
     }
 
     public show(ctxMenu: CTXMenu, eventOrElement: HTMLElement | MouseEvent, config: CTXConfig = {}) {
+        // Ensure styles are added before showing the first menu
+        ContextMenu.addStylesToDom();
+        
         if (eventOrElement instanceof MouseEvent) {
             eventOrElement.stopImmediatePropagation();
             eventOrElement.preventDefault();
@@ -184,9 +187,15 @@ class ContextMenu implements CTXMenuSingleton {
     }
 
     private static addStylesToDom() {
+        // Only add styles once
+        if (this.stylesAdded) return;
+        
         if (document.readyState === "loading") {
             return document.addEventListener("readystatechange", this.addStylesToDom, { once: true });
         }
+        
+        this.stylesAdded = true;
+        
         //insert default styles as first css -> low priority -> user can overwrite it easily
         const style = document.createElement("style");
         const nonce = ContextMenu.instance?.nonce;

--- a/src/ctxmenu.ts
+++ b/src/ctxmenu.ts
@@ -140,6 +140,9 @@ class ContextMenu implements CTXMenuSingleton {
     }
 
     public setNonce(nonce: string): void {
+        if (ContextMenu.stylesAdded) {
+            console.error('setNonce must be called before the first menu is shown. The nonce will have no effect.');
+        }
         this.nonce = nonce;
     }
 

--- a/src/ctxmenu.ts
+++ b/src/ctxmenu.ts
@@ -28,7 +28,7 @@ class ContextMenu implements CTXMenuSingleton {
      * in that case we don't want to close the menu. (#28)
      */
     private preventCloseOnScroll = false;
-    private nonce: string | undefined;
+    private static nonce: string | undefined;
     private static stylesAdded = false;
     private constructor() {
         window.addEventListener("click", () => void this.hide());
@@ -143,7 +143,7 @@ class ContextMenu implements CTXMenuSingleton {
         if (ContextMenu.stylesAdded) {
             console.error('setNonce must be called before the first menu is shown. The nonce will have no effect.');
         }
-        this.nonce = nonce;
+        ContextMenu.nonce = nonce;
     }
 
     private _hide(menuOrSubMenu: Element | undefined) {
@@ -201,10 +201,7 @@ class ContextMenu implements CTXMenuSingleton {
         
         //insert default styles as first css -> low priority -> user can overwrite it easily
         const style = document.createElement("style");
-        const nonce = ContextMenu.instance?.nonce;
-        if (nonce) {
-            style.nonce = nonce;
-        }
+        style.nonce = this.nonce ?? "";
         style.innerHTML = styles;
         document.head.insertBefore(style, document.head.childNodes[0]);
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -145,4 +145,9 @@ export interface CTXMenuSingleton {
      * Close any contextmenu that might be open at the moment
      */
     hide(): void;
+    /**
+     * Set a CSP nonce to be used for all style elements created by the library.
+     * @param nonce The CSP nonce value
+     */
+    setNonce(nonce: string): void;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -147,6 +147,8 @@ export interface CTXMenuSingleton {
     hide(): void;
     /**
      * Set a CSP nonce to be used for all style elements created by the library.
+     * 
+     * **Important:** This must be called before the first menu is shown, otherwise it will have no effect.
      * @param nonce The CSP nonce value
      */
     setNonce(nonce: string): void;


### PR DESCRIPTION
Add support to add a csp nonce to the created style attribute.
- Added a new function setNonce, which can be used to set a csp nonce before showing the first menu.
- If a nonce is added, it will be added in the function addStylesToDom() to the created style attribute.
- Changed when the function addStylesToDom() is called. Before it was called right after ctxmenu was loaded, which prevented that the nonce could be added. Now the styles are added before the first menu is shown, so that the nonce can be properly added.
- No breaking changes, nonce support is optional and it behaves the same as before, when no nonce is provided.

This PR closes #65 